### PR TITLE
Improving public API

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -17,7 +17,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+        with:
+          python-version: "3.10"
+      - name: Install tox
+        run: |
+          pip install tox
+
+      - name: Run pre-commit to check linting and typing
+        run: tox -e linting
+
   test:
+    needs: [linting]
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: absolufy-imports
 # sorting imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,3 +46,9 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.1.1
+    hooks:
+    - id: mypy
+      args: [--ignore-missing-imports]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@
 # Add the local code to the Python path, so docs are generated for
 # current working copy
 
+from typing import Any, Dict
+
 import napari_graph
 
 # -- General configuration ------------------------------------------------
@@ -156,7 +158,7 @@ htmlhelp_basename = 'napari-graph-docs'
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: Dict[str, Any] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ include_package_data = True
 packages = find:
 setup_requires = setuptools_scm
 install_requires =
+    networkx
     numba
     numpy
     pandas

--- a/src/napari_graph/__init__.py
+++ b/src/napari_graph/__init__.py
@@ -1,6 +1,6 @@
 from napari_graph.base_graph import BaseGraph
 from napari_graph.directed_graph import DirectedGraph
-from napari_graph.interops import to_napari_graph, to_networkx
+from napari_graph.interops import to_napari_graph
 from napari_graph.undirected_graph import UndirectedGraph
 
 try:
@@ -13,5 +13,4 @@ __all__ = [
     "DirectedGraph",
     "UndirectedGraph",
     "to_napari_graph",
-    "to_networkx",
 ]

--- a/src/napari_graph/__init__.py
+++ b/src/napari_graph/__init__.py
@@ -1,6 +1,6 @@
 from napari_graph.base_graph import BaseGraph
 from napari_graph.directed_graph import DirectedGraph
-from napari_graph.interops import from_networkx, to_networkx
+from napari_graph.interops import to_napari_graph, to_networkx
 from napari_graph.undirected_graph import UndirectedGraph
 
 try:
@@ -12,6 +12,6 @@ __all__ = [
     "BaseGraph",
     "DirectedGraph",
     "UndirectedGraph",
-    "from_networkx",
+    "to_napari_graph",
     "to_networkx",
 ]

--- a/src/napari_graph/_tests/test_graph.py
+++ b/src/napari_graph/_tests/test_graph.py
@@ -142,6 +142,11 @@ def test_node_addition_spatial() -> None:
     with pytest.raises(ValueError):
         graph.add_nodes(count=2)
 
+    with pytest.raises(ValueError):
+        graph.add_nodes(indices=[2, 3], coords=[[1, 2]])
+
+    assert len(graph) == 3
+
 
 @pytest.mark.parametrize(
     "graph_type,ndim",

--- a/src/napari_graph/_tests/test_graph.py
+++ b/src/napari_graph/_tests/test_graph.py
@@ -1,5 +1,5 @@
 from itertools import product
-from typing import Callable, List, Optional, Type
+from typing import Any, Callable, List, Optional, Protocol, Type
 
 import numpy as np
 import pandas as pd
@@ -157,7 +157,7 @@ def test_empty_graph(graph_type: Type[BaseGraph], ndim: Optional[int]) -> None:
 
 
 class TestGraph:
-    _GRAPH_CLASS: Type[BaseGraph] = ...
+    _GRAPH_CLASS: Type[BaseGraph]
     __test__ = False  # ignored for testing
     _index_shift = 0  # shift used to test special indexing
 
@@ -191,7 +191,9 @@ class TestGraph:
         )
 
     def teardown_method(self, method: Callable) -> None:
-        self.edges, self.coords, self.graph = None, None, None
+        del self.edges, self.graph
+        if hasattr(self, "coords"):
+            del self.coords
 
     def test_edge_buffers(self) -> None:
         # testing buffer correctness on a non-trivial case when a node was removed
@@ -229,6 +231,7 @@ class TestGraph:
 
 
 class TestDirectedGraph(TestGraph):
+    graph: DirectedGraph  # required by typing
     _GRAPH_CLASS = DirectedGraph
     __test__ = True
 
@@ -344,7 +347,13 @@ class TestUndirectedGraph(TestGraph):
             ]
 
 
-class NonSpatialMixin:
+class NonSpatialMixin(Protocol):
+    # required by typing
+    _GRAPH_CLASS: Any
+    graph: BaseGraph
+    edges: np.ndarray
+    _index_shift: int
+
     def setup_method(self, method: Callable) -> None:
         self.edges = (
             np.asarray([[0, 1], [1, 2], [2, 3], [3, 4], [4, 0]], dtype=int)

--- a/src/napari_graph/_tests/test_graph.py
+++ b/src/napari_graph/_tests/test_graph.py
@@ -206,6 +206,22 @@ class TestGraph:
         assert np.allclose(expected_indices, indices)
         assert np.allclose(expected_edges, edges)
 
+    def test_subgraph_edges(self) -> None:
+        # 3 is disconnected in subgraph
+        nodes_ids = np.asarray([0, 1, 3]) + self._index_shift
+
+        subgraph = self.graph.subgraph_edges(nodes_ids)
+        expected_subgraph = np.asarray([[0, 1]]) + self._index_shift
+
+        np.testing.assert_array_equal(subgraph, expected_subgraph)
+
+        buffer_node_ids = np.asarray([0, 1, 3])
+        buffer_subgraph = self.graph.subgraph_edges(
+            buffer_node_ids, is_buffer_domain=True
+        )
+
+        np.testing.assert_equal(buffer_subgraph, [[0, 1]])
+
 
 class TestDirectedGraph(TestGraph):
     _GRAPH_CLASS = DirectedGraph

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -1,4 +1,5 @@
-from typing import List
+import itertools
+from typing import Any, Callable, List
 
 import networkx as nx
 import numpy as np
@@ -9,7 +10,7 @@ from napari_graph import (
     BaseGraph,
     DirectedGraph,
     UndirectedGraph,
-    from_networkx,
+    to_napari_graph,
     to_networkx,
 )
 
@@ -60,11 +61,15 @@ def _graph_list() -> List[BaseGraph]:
     ]
 
 
-@pytest.mark.parametrize("in_graph", _graph_list())
-def test_networkx_conversion(in_graph: BaseGraph) -> None:
+@pytest.mark.parametrize(
+    "in_graph,to_class", itertools.product(_graph_list(), [to_networkx])
+)
+def test_conversion(
+    in_graph: BaseGraph, to_class: Callable[[BaseGraph], Any]
+) -> None:
 
-    nxgraph = to_networkx(in_graph)
-    out_graph = from_networkx(nxgraph)
+    nxgraph = to_class(in_graph)
+    out_graph = to_napari_graph(nxgraph)
 
     assert np.array_equal(in_graph.get_nodes(), out_graph.get_nodes())
 
@@ -91,7 +96,7 @@ def test_weighted_networkx_graph() -> None:
 
     nxgraph_edges = np.asarray(nxgraph.edges).sort()
 
-    graph = from_networkx(nxgraph)
+    graph = to_napari_graph(nxgraph)
     graph_edges = np.concatenate(graph.get_edges(), axis=0).sort()
 
     assert np.array_equal(nxgraph_edges, graph_edges)

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -100,3 +100,33 @@ def test_weighted_networkx_graph() -> None:
     graph_edges = np.concatenate(graph.get_edges(), axis=0).sort()
 
     assert np.array_equal(nxgraph_edges, graph_edges)
+
+
+def test_table_like_graphs() -> None:
+
+    coords = pd.DataFrame(
+        [
+            [0, 2.5],
+            [4, 2.5],
+            [1, 0],
+            [2, 3.5],
+            [3, 0],
+        ],
+        columns=["y", "x"],
+    )
+    coords.index = np.arange(
+        10, 5, -1
+    )  # testing index that don't start with zero
+
+    # testing pandas dataframe
+    graph = to_napari_graph(coords)
+    assert np.allclose(graph.get_coordinates(), coords)
+
+    # testing numpy array
+    graph = to_napari_graph(coords.to_numpy())
+    assert np.allclose(graph.get_coordinates(), coords.to_numpy())
+
+    # testing bad table
+    not_a_table = np.ones((5, 5, 5))
+    with pytest.raises(ValueError):
+        graph = to_napari_graph(not_a_table)

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -6,12 +6,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from napari_graph import (
+from napari_graph import (  # noqa
     BaseGraph,
     DirectedGraph,
     UndirectedGraph,
     to_napari_graph,
-    to_networkx,
 )
 
 
@@ -62,7 +61,8 @@ def _graph_list() -> List[BaseGraph]:
 
 
 @pytest.mark.parametrize(
-    "in_graph,to_class", itertools.product(_graph_list(), [to_networkx])
+    "in_graph,to_class",
+    itertools.product(_graph_list(), [BaseGraph.to_networkx]),
 )
 def test_conversion(
     in_graph: BaseGraph, to_class: Callable[[BaseGraph], Any]

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -1,5 +1,6 @@
 from typing import List
 
+import networkx as nx
 import numpy as np
 import pandas as pd
 import pytest
@@ -76,6 +77,21 @@ def test_networkx_conversion(in_graph: BaseGraph) -> None:
         assert out_graph.n_edges == 0
 
     else:
-        in_graph_edges = np.lexsort(in_graph.get_edges())
-        out_graph_edges = np.lexsort(out_graph.get_edges())
+        in_graph_edges = np.concatenate(in_graph.get_edges(), axis=0).sort()
+        out_graph_edges = np.concatenate(out_graph.get_edges(), axis=0).sort()
         assert np.array_equal(in_graph_edges, out_graph_edges)
+
+
+def test_weighted_networkx_graph() -> None:
+
+    nxgraph = nx.DiGraph()
+    nxgraph.add_edge(10, 11, weight=0.1)
+    nxgraph.add_edge(11, 12, weight=0.2)
+    nxgraph.add_edge(12, 10, weight=0.3)
+
+    nxgraph_edges = np.asarray(nxgraph.edges).sort()
+
+    graph = from_networkx(nxgraph)
+    graph_edges = np.concatenate(graph.get_edges(), axis=0).sort()
+
+    assert np.array_equal(nxgraph_edges, graph_edges)

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -11,7 +13,7 @@ from napari_graph import (
 )
 
 
-def _graph_list() -> list[BaseGraph]:
+def _graph_list() -> List[BaseGraph]:
 
     coords = pd.DataFrame(
         [

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Callable, List, Optional, Tuple, Union
 
+import networkx as nx
 import numpy as np
 import pandas as pd
 from numba import njit, typed
@@ -772,3 +775,67 @@ class BaseGraph:
     def is_spatial(self) -> bool:
         """True if self is a spatial graph (has coordinates attribute)."""
         return self._coords is not None
+
+    @staticmethod
+    def from_networkx(graph: nx.Graph) -> BaseGraph:
+        """Loads a Directed or Undirected napari-graph from a NetworkX graph.
+
+        Parameters
+        ----------
+        graph : nx.Graph
+            The NetworkX graph to be converted.
+        """
+        from napari_graph.directed_graph import DirectedGraph
+        from napari_graph.undirected_graph import UndirectedGraph
+
+        coords_dict = nx.get_node_attributes(graph, "pos")
+        if len(coords_dict) > 0:
+            coords_df = pd.DataFrame.from_dict(coords_dict, orient="index")
+        else:
+            coords_df = None
+
+        edges = graph.edges
+        if len(edges) > 0:
+            edges = np.atleast_2d(edges)
+
+        if graph.is_directed():
+            out_graph = DirectedGraph(edges, coords_df)
+        else:
+            out_graph = UndirectedGraph(edges, coords_df)
+
+        return out_graph
+
+    def to_networkx(self) -> nx.Graph:
+        """Convert it self into NetworkX graph.
+
+        Parameters
+        ----------
+        graph : BaseGraph
+            napari-graph Graph
+
+        Returns
+        -------
+        nx.Graph
+            An equivalent NetworkX graph.
+        """
+        from napari_graph.directed_graph import DirectedGraph
+
+        if isinstance(self, DirectedGraph):
+            out_graph = nx.DiGraph()
+        else:
+            out_graph = nx.Graph()
+
+        if self.is_spatial():
+            for node_id, pos in zip(self.get_nodes(), self.get_coordinates()):
+                out_graph.add_node(node_id, pos=pos)
+        else:
+            out_graph.add_nodes_from(self.get_nodes())
+
+        edges = self.get_edges()
+        if isinstance(edges, list) and len(edges) > 0:
+            edges = np.concatenate(edges, axis=0)
+
+        edges_as_tuples = list(map(tuple, edges))
+        out_graph.add_edges_from(edges_as_tuples)
+
+        return out_graph

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -895,3 +895,36 @@ class BaseGraph:
         out_graph.add_edges_from(edges_as_tuples)
 
         return out_graph
+
+    def subgraph_edges(
+        self,
+        node_indices: ArrayLike,
+        is_buffer_domain: bool = False,
+    ) -> ArrayLike:
+        """Returns edges (node pair) where both nodes are presents.
+
+        Parameters
+        ----------
+        nodes_indices : np.ndarray
+            Subset of nodes used for selection.
+        is_buffer_domain : bool
+            When true `node_indices` and returned edges are on buffer domain.
+
+        Returns
+        -------
+        np.ndarray
+            (N x 2) array of nodes indices, where N is the number of valid edges from the induced subgraph.
+        """
+        _, edges = self.get_edges_buffers(is_buffer_domain)
+
+        if is_buffer_domain:
+            mask = np.zeros(self._buffer2world.shape[0], dtype=bool)
+            mask[node_indices] = True
+            subgraph_edges = edges[mask[edges[:, 0]] & mask[edges[:, 1]]]
+
+        else:
+            mask = np.isin(edges, node_indices).all(axis=1)
+            assert mask.shape[0] == edges.shape[0]
+            subgraph_edges = edges[mask]
+
+        return subgraph_edges

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -192,9 +192,9 @@ class BaseGraph:
     """
 
     # abstract constants
-    _EDGE_DUPLICATION: int = ...
-    _EDGE_SIZE: int = ...
-    _LL_EDGE_POS: int = ...
+    _EDGE_DUPLICATION: int
+    _EDGE_SIZE: int
+    _LL_EDGE_POS: int
 
     # allocation constants
     _ALLOC_MULTIPLIER = 1.1
@@ -859,12 +859,11 @@ class BaseGraph:
         if len(edges) > 0:
             edges = np.atleast_2d(edges)
 
-        if graph.is_directed():
-            out_graph = DirectedGraph(edges, coords_df)
-        else:
-            out_graph = UndirectedGraph(edges, coords_df)
-
-        return out_graph
+        return (
+            DirectedGraph(edges, coords_df)
+            if graph.is_directed()
+            else UndirectedGraph(edges, coords_df)
+        )
 
     def to_networkx(self) -> nx.Graph:
         """Convert it self into NetworkX graph.

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -753,3 +753,13 @@ class BaseGraph:
             Boolean array of valid node, it has the same length the buffer.
         """
         return self._buffer2world != _NODE_EMPTY_PTR
+
+    @property
+    def coords_buffer(self) -> np.ndarray:
+        """Returns the actual coordinates buffer. It's not a copy."""
+        if self._coords is None:
+            raise ValueError(
+                "graph does not have a `coords` attribute. "
+                "It is not a spatial graph."
+            )
+        return self._coords

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -743,3 +743,13 @@ class BaseGraph:
     def __len__(self) -> int:
         """Number of nodes in use."""
         return self.n_nodes
+
+    def initialized_buffer_mask(self) -> np.ndarray:
+        """Compute mask of nodes that have already been initialized.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean array of valid node, it has the same length the buffer.
+        """
+        return self._buffer2world != _NODE_EMPTY_PTR

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -457,6 +457,11 @@ class BaseGraph:
         buffer_indices = np.flip(self._empty_nodes[-len(indices) :])
 
         if coords is not None:
+            if indices.shape[0] != coords.shape[0]:
+                raise ValueError(
+                    f"`indices` and `coords` must be equal. Found {len(indices)} and {len(coords)}."
+                )
+
             self._coords[buffer_indices] = coords
 
         _update_world2buffer(self._world2buffer, indices, buffer_indices)

--- a/src/napari_graph/directed_graph.py
+++ b/src/napari_graph/directed_graph.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
-import pandas as pd
 from numba import njit, typed
 from numpy.typing import ArrayLike
 
@@ -356,28 +355,6 @@ class DirectedGraph(BaseGraph):
         self._node2tgt_edges = np.full(
             n_nodes, fill_value=_EDGE_EMPTY_PTR, dtype=int
         )
-
-    def init_nodes(
-        self,
-        coords: Union[pd.DataFrame, ArrayLike],
-    ) -> None:
-        """Initialize graph nodes from coordinates data.
-
-        Graph nodes will be indexed by data frame (or array) indices.
-
-        Parameters
-        ----------
-        coords : Union[pd.DataFrame, ArrayLike],
-            2-dim array containing nodes coordinates.
-        """
-        super().init_nodes(coords)
-        n_nodes = len(coords)
-        if len(self._node2tgt_edges) < n_nodes:
-            self._node2tgt_edges = np.full(
-                n_nodes, fill_value=_EDGE_EMPTY_PTR, dtype=np.int64
-            )
-        else:
-            self._node2tgt_edges.fill(_EDGE_EMPTY_PTR)
 
     def _realloc_nodes_buffers(self, size: int) -> None:
         diff_size = size - self.n_allocated_nodes

--- a/src/napari_graph/interops.py
+++ b/src/napari_graph/interops.py
@@ -79,6 +79,8 @@ def to_networkx(graph: BaseGraph) -> nx.Graph:
 COMPATIPLE_CLASSES = {
     BaseGraph: lambda x: x,
     nx.Graph: from_networkx,
+    pd.DataFrame: lambda x: UndirectedGraph(coords=x),
+    np.ndarray: lambda x: UndirectedGraph(coords=x),
 }
 
 

--- a/src/napari_graph/interops.py
+++ b/src/napari_graph/interops.py
@@ -76,7 +76,7 @@ def to_networkx(graph: BaseGraph) -> nx.Graph:
     return out_graph
 
 
-COMPATIPLE_CLASSES = {
+COMPATIBLE_CLASSES = {
     BaseGraph: lambda x: x,
     nx.Graph: from_networkx,
     pd.DataFrame: lambda x: UndirectedGraph(coords=x),

--- a/src/napari_graph/interops.py
+++ b/src/napari_graph/interops.py
@@ -5,80 +5,11 @@ import numpy as np
 import pandas as pd
 
 from napari_graph.base_graph import BaseGraph
-from napari_graph.directed_graph import DirectedGraph
 from napari_graph.undirected_graph import UndirectedGraph
-
-
-def from_networkx(graph: nx.Graph) -> BaseGraph:
-    """Convert a NetworkX graph into a napari-graph UndirectedGraph or DirectedGraph.
-
-    Parameters
-    ----------
-    graph : nx.Graph
-        The NetworkX graph to be converted.
-
-    Returns
-    -------
-    BaseGraph
-        An equivalent napari-graph UndirectedGraph or DirectedGraph.
-    """
-
-    coords_dict = nx.get_node_attributes(graph, "pos")
-    if len(coords_dict) > 0:
-        coords_df = pd.DataFrame.from_dict(coords_dict, orient="index")
-    else:
-        coords_df = None
-
-    edges = graph.edges
-    if len(edges) > 0:
-        edges = np.atleast_2d(edges)
-
-    if graph.is_directed():
-        out_graph = DirectedGraph(edges, coords_df)
-    else:
-        out_graph = UndirectedGraph(edges, coords_df)
-
-    return out_graph
-
-
-def to_networkx(graph: BaseGraph) -> nx.Graph:
-    """Convert a napari-graph UndirectedGraph or DirectedGraph into NetworkX graph.
-
-    Parameters
-    ----------
-    graph : BaseGraph
-        napari-graph Graph
-
-    Returns
-    -------
-    nx.Graph
-        An equivalent NetworkX graph.
-    """
-
-    if isinstance(graph, DirectedGraph):
-        out_graph = nx.DiGraph()
-    else:
-        out_graph = nx.Graph()
-
-    if graph.is_spatial():
-        for node_id, pos in zip(graph.get_nodes(), graph.get_coordinates()):
-            out_graph.add_node(node_id, pos=pos)
-    else:
-        out_graph.add_nodes_from(graph.get_nodes())
-
-    edges = graph.get_edges()
-    if isinstance(edges, list) and len(edges) > 0:
-        edges = np.concatenate(edges, axis=0)
-
-    edges_as_tuples = list(map(tuple, edges))
-    out_graph.add_edges_from(edges_as_tuples)
-
-    return out_graph
-
 
 COMPATIBLE_CLASSES = {
     BaseGraph: lambda x: x,
-    nx.Graph: from_networkx,
+    nx.Graph: BaseGraph.from_networkx,
     pd.DataFrame: lambda x: UndirectedGraph(coords=x),
     np.ndarray: lambda x: UndirectedGraph(coords=x),
 }
@@ -88,6 +19,7 @@ def to_napari_graph(graph: Any) -> BaseGraph:
     """Generic function to convert "any" graph to a napari-graph.
 
     Supported formats:
+        - napari-graph (it self)
         - NetworkX
 
     Parameters

--- a/src/napari_graph/interops.py
+++ b/src/napari_graph/interops.py
@@ -100,7 +100,7 @@ def to_napari_graph(graph: Any) -> BaseGraph:
     BaseGraph
         A napari-graph graph.
     """
-    for cls, conversion_func in COMPATIPLE_CLASSES.items():
+    for cls, conversion_func in COMPATIBLE_CLASSES.items():
         if isinstance(graph, cls):
             return conversion_func(graph)
 

--- a/src/napari_graph/interops.py
+++ b/src/napari_graph/interops.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -74,3 +76,34 @@ def to_networkx(graph: BaseGraph) -> nx.Graph:
     out_graph.add_edges_from(edges_as_tuples)
 
     return out_graph
+
+
+COMPATIPLE_CLASSES = {
+    BaseGraph: lambda x: x,
+    nx.Graph: from_networkx,
+}
+
+
+def to_napari_graph(graph: Any) -> BaseGraph:
+    """Generic function to convert "any" graph to a napari-graph.
+
+    Supported formats:
+        - NetworkX
+
+    Parameters
+    ----------
+    graph : Any
+        Any kind of graph to a napari-graph. See supported formats above.
+
+    Returns
+    -------
+    BaseGraph
+        A napari-graph graph.
+    """
+    for cls, conversion_func in COMPATIPLE_CLASSES.items():
+        if isinstance(graph, cls):
+            return conversion_func(graph)
+
+    raise NotImplementedError(
+        f"Conversion from {type(graph)} to napari-graph does not exist."
+    )

--- a/src/napari_graph/interops.py
+++ b/src/napari_graph/interops.py
@@ -1,5 +1,3 @@
-import warnings
-
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -30,11 +28,9 @@ def from_networkx(graph: nx.Graph) -> BaseGraph:
     else:
         coords_df = None
 
-    edges = np.asarray(graph.edges)
-
-    if edges.ndim > 1 and edges.shape[1] > 2:
-        warnings.warn("Edges weights are not supported yet and were ignored.")
-        edges = edges[:, :2]
+    edges = graph.edges
+    if len(edges) > 0:
+        edges = np.atleast_2d(edges)
 
     if graph.is_directed():
         out_graph = DirectedGraph(edges, coords_df)


### PR DESCRIPTION
@jni This PR implements new methods to avoid using private attributes in the napari graph layer implementation, PR napari/napari#5861

Notes:
- there's already a method called `get_coordinates` but it returns only the valid coordinates (initialized nodes) and the napari layer operates on the buffer directly (to be very efficient) so I added a additional method `coords_buffer`.