### PR TITLE
Add support for networkx graphs with non-integer node IDs

### DIFF
--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -136,7 +136,7 @@ def test_networkx_non_integer_ids():
     """Check that passing nx graph with non-integer IDs doesn't crash."""
     g = nx.hexagonal_lattice_graph(5, 5, with_positions=True)
     with pytest.warns(UserWarning, match='Node IDs must be integers.'):
-        ng = BaseGraph.from_networkx(g)
+        BaseGraph.from_networkx(g)
 
 
 def test_networkx_basic_roundtrip():
@@ -153,4 +153,3 @@ def test_networkx_basic_roundtrip():
         np.testing.assert_allclose(
             gint.nodes[node]['pos'], g2.nodes[node]['pos']
         )
-

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -130,3 +130,10 @@ def test_table_like_graphs() -> None:
     not_a_table = np.ones((5, 5, 5))
     with pytest.raises(ValueError):
         graph = to_napari_graph(not_a_table)
+
+
+def test_networkx_non_integer_ids():
+    """Check that passing nx graph with non-integer IDs doesn't crash."""
+    g = nx.hexagonal_lattice_graph(5, 5, with_positions=True)
+    with pytest.warns(UserWarning, match='Node IDs must be integers.'):
+        ng = BaseGraph.from_networkx(g)

--- a/src/napari_graph/_tests/test_interops.py
+++ b/src/napari_graph/_tests/test_interops.py
@@ -137,3 +137,20 @@ def test_networkx_non_integer_ids():
     g = nx.hexagonal_lattice_graph(5, 5, with_positions=True)
     with pytest.warns(UserWarning, match='Node IDs must be integers.'):
         ng = BaseGraph.from_networkx(g)
+
+
+def test_networkx_basic_roundtrip():
+    g = nx.hexagonal_lattice_graph(5, 5, with_positions=True)
+    gint = nx.convert_node_labels_to_integers(g)
+    ng = BaseGraph.from_networkx(gint)
+    g2 = ng.to_networkx()
+    # convert positions to tuples because nx comparison tools don't like arrays
+    for node in g2.nodes():
+        g2.nodes[node]['pos'] = tuple(g2.nodes[node]['pos'])
+    assert nx.utils.edges_equal(gint.edges, g2.edges)
+    assert set(gint.nodes) == set(g2.nodes)
+    for node in gint.nodes:
+        np.testing.assert_allclose(
+            gint.nodes[node]['pos'], g2.nodes[node]['pos']
+        )
+

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -851,7 +851,7 @@ class BaseGraph:
         from napari_graph.undirected_graph import UndirectedGraph
 
         nodes = np.array(list(graph.nodes()))
-        if not(np.issubdtype(nodes.dtype, np.integer)) or nodes.ndim > 1:
+        if not (np.issubdtype(nodes.dtype, np.integer)) or nodes.ndim > 1:
             graph_int_nodes = nx.convert_node_labels_to_integers(
                 graph, label_attribute='_node_id'
             )

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -851,7 +851,7 @@ class BaseGraph:
         from napari_graph.undirected_graph import UndirectedGraph
 
         nodes = np.array(list(graph.nodes()))
-        if not (np.issubdtype(nodes.dtype, np.integer)) or nodes.ndim > 1:
+        if not np.issubdtype(nodes.dtype, np.integer) or nodes.ndim > 1:
             graph_int_nodes = nx.convert_node_labels_to_integers(
                 graph, label_attribute='_node_id'
             )

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -899,6 +899,9 @@ class BaseGraph:
 
         if self.is_spatial():
             for node_id, pos in zip(self.get_nodes(), self.get_coordinates()):
+                # note: some nx functions are unhappy with arrays in node
+                # attributes because you can't compare arrays with ==.
+                # So one day we might want to cast to tuple.
                 out_graph.add_node(node_id, pos=pos)
         else:
             out_graph.add_nodes_from(self.get_nodes())


### PR DESCRIPTION
Some nx graph generation routines don't give integer node IDs, which caused a
crash in the dataframe parsing.

- Add test for non-integer-ID nx Graph conversion
- Fix conversion of nx graphs with non-integer IDs
- Add test for networkx round trip
- Add note about compatibility of array attributes
