### PR TITLE
Update from macos-11 to macos-13 on github actions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ PLATFORM =
     ubuntu-20.04: linux
     windows-latest: windows
     macos-latest: macos
-    macos-11: macos
+    macos-13: macos
 
 [testenv]
 deps =


### PR DESCRIPTION
Github Actions macos-11 runner will be deprecated soon, upgrade to macos-13 in `tox.ini`.


