### PR TITLE
Use codecov v4, single upload step, and non-codecov reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,8 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
+source =
+    napari_graph
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -13,7 +15,3 @@ exclude_lines =
 source =
     src/
     */site-packages
-
-[run]
-source =
-    napari_graph

--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,8 @@
 branch = True
 source =
     napari_graph
+omit =
+    */_version.py
 
 [report]
 # Regexes for lines to exclude from consideration
@@ -14,4 +16,4 @@ exclude_lines =
 [paths]
 source =
     src/
-    */site-packages
+    */site-packages/

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,3 +7,13 @@ branch = True
 exclude_lines =
     except ImportError:
     @(abc\.)?abstractmethod
+
+
+[paths]
+source =
+    src/
+    */site-packages
+
+[run]
+source =
+    napari_graph

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -116,9 +116,16 @@ jobs:
           pattern: cov-reports-*
           path: coverage
           merge-multiple: true
+      - name: Uproad coverage input
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_part
+          path: coverage
+          retention-days: 5
+
       - name: combine coverage data
         run: |
-          python -Im coverage combine coverage
+          python -Im coverage combine --debug=pathmap coverage
           python -Im coverage xml -o coverage.xml
           # Report and write to summary.
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -20,8 +20,8 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
 
         with:
           python-version: "3.10"
@@ -39,13 +39,13 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -86,10 +86,58 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
 
-      - name: Coverage
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage data
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.coverage }}
+        with:
+          name: cov-reports-${{ matrix.platform }}-py-${{ matrix.python-version }}
+          path: |
+            ./.coverage.*
+
+
+  coverage_prepare:
+    name: Prepare coverage
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache-dependency-path: pyproject.toml
+          cache: 'pip'
+      - name: Install Dependencies
+        run: |
+          pip install --upgrade pip
+          pip install codecov
+
+      - name: Download coverage data
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cov-reports-*
+          path: coverage
+          merge-multiple: true
+      - name: combine coverage data
+        run: |
+          python -Im coverage combine coverage
+          python -Im coverage xml -o coverage.xml
+          # Report and write to summary.
+          python -Im coverage report --format=markdown --skip-empty --skip-covered >> $GITHUB_STEP_SUMMARY
+          coverage report -m --fail-under 80
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage_xml
+          path: coverage.xml
+          retention-days: 5
+
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: combine coverage data
         run: |
-          python -Im coverage combine --debug=pathmap coverage
+          python -Im coverage combine --debug=pathmap,config coverage
           python -Im coverage xml -o coverage.xml
           # Report and write to summary.
           python -Im coverage report --format=markdown --skip-empty --skip-covered >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -88,7 +88,6 @@ jobs:
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
-        if: ${{ inputs.coverage }}
         with:
           name: cov-reports-${{ matrix.platform }}-py-${{ matrix.python-version }}
           path: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # basic pre-commit
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -9,31 +9,31 @@ repos:
       - id: check-yaml
 # make every import absolute
   - repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.0
+    rev: v0.3.1
     hooks:
       - id: absolufy-imports
 # sorting imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
 # automatic upgrade to newer python versions syntax
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.30.0
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args: ["--py37-plus", "--keep-runtime-typing"]
 # syntax linting and formatting
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: [--in-place, --remove-all-unused-imports,
                --ignore-init-module-imports]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies: [flake8-typing-imports==1.12.0]
@@ -43,12 +43,12 @@ repos:
                '__init__.py:F401']
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 24.4.2
     hooks:
       - id: black
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.10.0
     hooks:
     - id: mypy
       args: [--ignore-missing-imports]

--- a/src/napari_graph/_tests/test_graph.py
+++ b/src/napari_graph/_tests/test_graph.py
@@ -366,7 +366,7 @@ class NonSpatialMixin(Protocol):
         pytest.skip("Non-spatial graph has no coordinates.")
 
 
-class TestNonSpatialDirectedGraph(NonSpatialMixin, TestDirectedGraph):
+class TestNonSpatialDirectedGraph(NonSpatialMixin, TestDirectedGraph):  # type: ignore[misc]
     pass
 
 

--- a/src/napari_graph/base_graph.py
+++ b/src/napari_graph/base_graph.py
@@ -545,9 +545,9 @@ class BaseGraph:
         ] = np.arange(prev_size + 1, size)
 
         # appends existing empty edges linked list to the end of the new list
-        self._edges_buffer[
-            self._LL_EDGE_POS - self._EDGE_SIZE
-        ] = self._empty_edge_idx
+        self._edges_buffer[self._LL_EDGE_POS - self._EDGE_SIZE] = (
+            self._empty_edge_idx
+        )
         self._empty_edge_idx = prev_size
 
     @property
@@ -744,17 +744,21 @@ class BaseGraph:
 
         if mode.lower() == 'indices':
             edges_data = [
-                self._buffer2world[e].reshape(-1, 2)
-                if len(e) > 0
-                else np.empty((0, 2))
+                (
+                    self._buffer2world[e].reshape(-1, 2)
+                    if len(e) > 0
+                    else np.empty((0, 2))
+                )
                 for e in flat_edges
             ]
         elif mode.lower() == 'coords':
             ndim = self._coords.shape[1]
             edges_data = [
-                self._coords[e].reshape(-1, 2, ndim)
-                if len(e) > 0
-                else np.empty((0, 2, ndim))
+                (
+                    self._coords[e].reshape(-1, 2, ndim)
+                    if len(e) > 0
+                    else np.empty((0, 2, ndim))
+                )
                 for e in flat_edges
             ]
         # NOTE: here `mode` could also query the edges features.

--- a/src/napari_graph/directed_graph.py
+++ b/src/napari_graph/directed_graph.py
@@ -163,13 +163,13 @@ def _remove_target_edge(
         ):  # different indexing from source edge
             # skipping found edge from linked list
             if prev_buffer_idx == _EDGE_EMPTY_PTR:
-                node2tgt_edges[
-                    tgt_node
-                ] = next_edge_idx  # different indexing from source edge
+                node2tgt_edges[tgt_node] = (
+                    next_edge_idx  # different indexing from source edge
+                )
             else:
-                edges_buffer[
-                    prev_buffer_idx + _LL_DI_EDGE_POS + 1
-                ] = next_edge_idx
+                edges_buffer[prev_buffer_idx + _LL_DI_EDGE_POS + 1] = (
+                    next_edge_idx
+                )
 
             edges_buffer[buffer_idx + _LL_DI_EDGE_POS + 1] = _EDGE_EMPTY_PTR
             break

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     pytest
     coverage
 commands =
-    coverage run --source=napari_graph --branch -m pytest .
+    coverage run --parallel-mode --source=napari_graph --branch -m pytest .
 
 [testenv:linting]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -34,3 +34,10 @@ commands =
 [testenv:linting]
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
+
+
+[coverage:paths]
+source = [
+    "src/napari_graph/",
+    ".tox/*/lib/python*/site-packages/napari_graph/"
+]

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 
 [coverage:paths]
-source = [
-    "src/napari_graph/",
-    ".tox/*/lib/python*/site-packages/napari_graph/"
-]
+source =
+    src/napari_graph/
+    .tox/*/lib/python*/site-packages/napari_graph/

--- a/tox.ini
+++ b/tox.ini
@@ -34,13 +34,3 @@ commands =
 [testenv:linting]
 deps = pre-commit
 commands = pre-commit run --all-files --show-diff-on-failure
-
-
-[coverage:paths]
-source =
-    src/
-    */site-packages
-
-[coverage:run]
-source =
-    napari_graph

--- a/tox.ini
+++ b/tox.ini
@@ -38,5 +38,9 @@ commands = pre-commit run --all-files --show-diff-on-failure
 
 [coverage:paths]
 source =
-    src/napari_graph/
-    .tox/*/lib/python*/site-packages/napari_graph/
+    src/
+    */site-packages
+
+[coverage:run]
+source =
+    napari_graph

--- a/tox.ini
+++ b/tox.ini
@@ -30,8 +30,6 @@ deps =
     coverage
 commands =
     coverage run --source=napari_graph --branch -m pytest .
-    coverage report -m --fail-under 80
-    coverage xml
 
 [testenv:linting]
 deps = pre-commit


### PR DESCRIPTION
This PR solves https://github.com/napari/napari-graph/pull/13#issuecomment-2141196170 and moves coverage upload to a separate step to make the CI logs cleaner.

It also adds support for GHA-only coverage reports using the method from
[hynek.me/articles/ditch-codecov-python](https://hynek.me/articles/ditch-codecov-python/)